### PR TITLE
Fix interaction default detection

### DIFF
--- a/docs/sglang_multiturn/interaction_system.rst
+++ b/docs/sglang_multiturn/interaction_system.rst
@@ -266,7 +266,9 @@ Each sample can specify which interaction to use via the ``name`` field. This en
 
 **Backward Compatibility**
 
-If no ``name`` field is provided in ``interaction_kwargs``, the system defaults to ``"gsm8k"`` for backward compatibility.
+If no ``name`` field is provided in ``interaction_kwargs``, the system will use
+the only available interaction if there's exactly one defined. Otherwise it
+defaults to ``"gsm8k"`` for backward compatibility.
 
 Best Practices
 --------------

--- a/verl/workers/rollout/sglang_rollout/sglang_rollout.py
+++ b/verl/workers/rollout/sglang_rollout/sglang_rollout.py
@@ -954,9 +954,12 @@ class SGLangRollout(BaseRollout):
                 messages = [{"role": x.role, "content": x.content} for x in _req.messages]
 
                 # Get interaction by name from interaction_kwargs
-                interaction_name = _req.interaction_kwargs.get(
-                    "name", "gsm8k"
-                )  # Default to gsm8k for backward compatibility
+                interaction_name = _req.interaction_kwargs.get("name")
+                if interaction_name is None:
+                    if len(self.interaction_map) == 1:
+                        interaction_name = next(iter(self.interaction_map))
+                    else:
+                        interaction_name = "gsm8k"  # Backward compatibility
                 if interaction_name not in self.interaction_map:
                     raise ValueError(
                         f"Interaction '{interaction_name}' not found in interaction_map. Available interactions: "
@@ -1032,7 +1035,12 @@ class SGLangRollout(BaseRollout):
         if _req.interaction_kwargs and self.interaction_map:
             interaction_kwargs = _req.interaction_kwargs
             # Get interaction by name from interaction_kwargs
-            interaction_name = interaction_kwargs.get("name", "gsm8k")  # Default to gsm8k for backward compatibility
+            interaction_name = interaction_kwargs.get("name")
+            if interaction_name is None:
+                if len(self.interaction_map) == 1:
+                    interaction_name = next(iter(self.interaction_map))
+                else:
+                    interaction_name = "gsm8k"  # Backward compatibility
             if interaction_name not in self.interaction_map:
                 raise ValueError(
                     f"Interaction '{interaction_name}' not found in interaction_map. Available interactions: "


### PR DESCRIPTION
## Summary
- better default selection when interaction name is missing
- document new default behaviour for interactions

## Testing
- `ruff check --fix verl/workers/rollout/sglang_rollout/sglang_rollout.py`
- `ruff format verl/workers/rollout/sglang_rollout/sglang_rollout.py`
- `mypy verl/workers/rollout/sglang_rollout/sglang_rollout.py`
- ❌ `pre-commit run --files ...` *(failed: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688c4e86a314832d88a50855f6da996f