### PR TITLE
Fix missing key in tau retail tool

### DIFF
--- a/verl/tools/tau_retail/find_user_id_by_email.py
+++ b/verl/tools/tau_retail/find_user_id_by_email.py
@@ -78,9 +78,9 @@ class FindUserIdByEmail(BaseTool):
     async def execute(self, instance_id: str, parameters: dict[str, Any], **kwargs) -> tuple[str, float, dict]:
         email = parameters.get("email", "")
         data = kwargs.get("data", {})
-        if data is None:
+        if not data or "users" not in data:
             return "Error: data is not provided"
-        users = data["users"]
+        users = data.get("users", {})
         for user_id, profile in users.items():
             if profile["email"].lower() == email.lower():
                 return user_id


### PR DESCRIPTION
## Summary
- handle the case where `data` lacks a `users` key
- still return error when dataset isn't provided

## Testing
- `pytest tests/special_sanity/test_import.py::test_import -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_688c670594d8832d84d4acf099a98125