### PR TITLE
Fix tau retail data handling

### DIFF
--- a/verl/tools/tau_retail/find_user_id_by_email.py
+++ b/verl/tools/tau_retail/find_user_id_by_email.py
@@ -43,7 +43,10 @@ class FindUserIdByEmail(BaseTool):
             "type": "function",
             "function": {
                 "name": "find_user_id_by_email",
-                "description": "Find user id by email. If the user is not found, the function will return an error message.",
+                "description": (
+                    "Find user id by email. If the user is not found, the function "
+                    "will return an error message."
+                ),
                 "parameters": {
                     "type": "object",
                     "properties": {


### PR DESCRIPTION
## Summary
- load tau retail dataset per interaction session
- expose helper to get loaded data
- use session data when executing tools
- wrap long descriptions to satisfy linter

## Testing
- `ruff check verl/interactions/tau_retail_interaction.py`
- `ruff check verl/tools/tau_retail/find_user_id_by_email.py`
- `ruff check verl/workers/rollout/sglang_rollout/sglang_rollout.py`
- `mypy verl/interactions/tau_retail_interaction.py verl/tools/tau_retail/find_user_id_by_email.py verl/workers/rollout/sglang_rollout/sglang_rollout.py`
- `pip install pre-commit` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_688d64deee7c832da9f4585a60b287bd