### PR TITLE
Ensure tool kwargs default and validate tool presence

### DIFF
--- a/verl/workers/rollout/sglang_rollout/sglang_rollout.py
+++ b/verl/workers/rollout/sglang_rollout/sglang_rollout.py
@@ -846,7 +846,7 @@ class SGLangRollout(BaseRollout):
                 _req.state = AsyncRolloutRequestStateEnum.RUNNING
             elif _req.state == AsyncRolloutRequestStateEnum.TOOL_CALLING:
                 if _req.messages[-1].tool_calls is not None:
-                    parsed_tool_calls = _req.messages[-1].tool_calls
+                    parsed_tool_calls = list(_req.messages[-1].tool_calls)
 
                     interaction_name = _req.interaction_kwargs.get("name")
                     if interaction_name is None:
@@ -859,20 +859,35 @@ class SGLangRollout(BaseRollout):
                     if interaction is not None and hasattr(interaction, "get_data"):
                         data = interaction.get_data(_req.request_id)
 
-                    tool_call_results = await asyncio.gather(
-                        *[
-                            self._tool_map[tool_call.function.name].execute(
-                                _req.request_id,
-                                tool_call.function.arguments,
-                                data=data,
-                                **_req.tools_kwargs[tool_call.function.name].get("execute_kwargs", {}),
+                    execute_tasks = []
+                    for call in parsed_tool_calls:
+                        tool = self._tool_map.get(call.function.name)
+                        if tool is None:
+                            raise ValueError(
+                                f"Tool {call.function.name} not found in tool map"
                             )
-                            for tool_call in parsed_tool_calls
-                        ]
+                        kwargs = (
+                            (_req.tools_kwargs or {})
+                            .get(call.function.name, {})
+                            .get("execute_kwargs", {})
+                        )
+                        execute_tasks.append(
+                            tool.execute(
+                                _req.request_id,
+                                call.function.arguments,
+                                data=data,
+                                **kwargs,
+                            )
+                        )
+
+                    tool_call_results = await asyncio.gather(*execute_tasks)
+                    _req.add_tool_response_messages(
+                        self.processing_class, [resp for resp, _, _ in tool_call_results]
                     )
-                    _req.add_tool_response_messages(self.processing_class, [resp for resp, _, _ in tool_call_results])
-                    for tool_call, (resp, reward, metrics) in zip(parsed_tool_calls, tool_call_results, strict=True):
-                        _req.update_metrics(metrics, tool_call.function.name)
+                    for call, (resp, reward, metrics) in zip(
+                        parsed_tool_calls, tool_call_results, strict=True
+                    ):
+                        _req.update_metrics(metrics, call.function.name)
                     if len(_req.input_ids) >= self.config.max_model_len:
                         finish_reason_type = FinishReasonTypeEnum.STOP
                         break


### PR DESCRIPTION
## Summary
- build tool execution tasks sequentially, checking for missing tools and defaulting `tools_kwargs` to avoid KeyErrors

## Testing
- `pytest tests/test_base_config_on_cpu.py tests/test_protocol_on_cpu.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy; proxy 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688d80b7c8b0832db293985d9398e01a