### PR TITLE
Register name-zip lookup tool for Tau Retail rollout

### DIFF
--- a/examples/data_preprocess/tau_retail/preprocess_tau_retail_dataset.py
+++ b/examples/data_preprocess/tau_retail/preprocess_tau_retail_dataset.py
@@ -82,6 +82,9 @@ if __name__ == "__main__":
                             # "calc_reward_kwargs": {},
                             # "release_kwargs": {},
                         },
+                        "find_user_id_by_name_zip": {
+                            "create_kwargs": {"ground_truth": ""},
+                        },
                     },
                     "interaction_kwargs": {
                         "query": task.instruction,

--- a/examples/sglang_multiturn/config/tool_config/tau_retail_tool_config.yaml
+++ b/examples/sglang_multiturn/config/tool_config/tau_retail_tool_config.yaml
@@ -15,7 +15,8 @@ tools:
               description: "The email of the user, such as 'something@example.com'."
           required: ["email"]
   - class_name: "verl.tools.tau_retail.find_user_id_by_name_zip.FindUserIdByNameZip"
-    config: 
+    # Retrieve a user's ID using first/last name and zip code
+    config:
       type: native
     tool_schema:
       type: "function"

--- a/verl/workers/rollout/sglang_rollout/sglang_rollout.py
+++ b/verl/workers/rollout/sglang_rollout/sglang_rollout.py
@@ -1045,7 +1045,7 @@ class SGLangRollout(BaseRollout):
             tool_creation_coroutines = []
             for tool_schema in _req.tool_schemas:
                 tool = self._tool_map[tool_schema.function.name]
-                create_kwargs = _req.tools_kwargs[tool.name].get("create_kwargs", {})
+                create_kwargs = (_req.tools_kwargs or {}).get(tool.name, {}).get("create_kwargs", {})
                 tool_creation_coroutines.append(tool.create(_req.request_id, **create_kwargs))
             await asyncio.gather(*tool_creation_coroutines)
         if _req.interaction_kwargs and self.interaction_map:


### PR DESCRIPTION
## Summary
- register `find_user_id_by_name_zip` in Tau Retail tool configuration
- supply `find_user_id_by_name_zip` kwargs in Tau Retail dataset generation and guard against missing tool kwargs during rollout

## Testing
- `pytest tests/utils/dataset/test_rl_collate_fn_on_cpu.py::test_rl_collate_fn` *(failed: No module named 'torch')*
- `pip install torch` *(failed: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_688d9272ad48832db581aadd64e79a3b